### PR TITLE
feat(parts-stock-mobility): Store stock mobility data for manual processes

### DIFF
--- a/app/templates/aircrafts/index.html
+++ b/app/templates/aircrafts/index.html
@@ -41,9 +41,9 @@
 
     .logout-button {
         position: absolute;
-        right: .50rem;
+        right: 2%;
         top: 3%;
-        width: 300px;
+        width: 200px;
         height: 50px;
         border-radius: 5px;
         display: flex;

--- a/app/templates/login/index.html
+++ b/app/templates/login/index.html
@@ -52,7 +52,7 @@
         }
 
         .warning_text {
-            color: rgb(189, 2, 2);
+            background-color: rgb(246, 67, 67);
             font-size: 18px;
             font-weight: bold;
             text-decoration: underline;

--- a/app/templates/parts/index.html
+++ b/app/templates/parts/index.html
@@ -11,14 +11,22 @@
 <style>
     .logout-button {
         position: absolute;
-        right: .50rem;
+        right: 2%;
         top: 3%;
-        width: 300px;
+        width: 200px;
         height: 50px;
         border-radius: 5px;
         display: flex;
         justify-content: center;
         align-items: center;
+    }
+
+    .stock-decrease {
+        background-color: #fa020240 !important;
+    }
+
+    .stock-increase {
+        background-color: #2ff50740 !important;
     }
 </style>
 
@@ -41,6 +49,22 @@
             </thead>
             <tbody></tbody>
         </table>
+        <h1 class="d-flex justify-content-center text-decoration-underline">Part Stock Mobility</h1>
+        <hr>
+        <table id="aircraft-productions-table">
+            <thead>
+                <tr>
+                    <th>Part Name</th>
+                    <th>Description</th>
+                    <th>Process Type</th>
+                    <th>Done By</th>
+                    <th>Process Date</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+        <!-- If the user isn in the assembly team, then the user shouldn't have acces to edit part counts in stocks  -->
+        {% if has_assemble_permission is True %}
         <div class="row">
             <div class="col-6 mt-5">
                 <h1 class="d-flex justify-content-center text-decoration-underline">Add parts to stock</h1>
@@ -110,6 +134,7 @@
                 </div>
             </div>
         </div>
+        {% endif %}
     </div>
 
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
@@ -118,6 +143,7 @@
         $(document).ready(function () {
             $('#parts-table').dataTable({
                 serverSide: true,
+                responsive: true,
                 sAjaxSource: "http://localhost:8000/partsData/",
                 columns: [
                     {
@@ -137,6 +163,47 @@
                         data: 3
                     }
                 ]
+            });
+
+            const dateFormatter = date => new Date(date).toLocaleDateString("en-US", { month: "short", day: "2-digit", year: "numeric" });
+            $(document).ready(function () {
+                $('#aircraft-productions-table').dataTable({
+                    serverSide: true,
+                    sAjaxSource: "http://localhost:8000/partStockMobilityData/",
+                    createdRow: (row, data) => {
+                        const [, , , status] = data;
+                        /** 
+                        * Display red color on background for stock decrease processes
+                        * Display green color on background for stock increase processes
+                        */
+                        $(row).addClass(status.toLowerCase().includes('increase') ? 'stock-increase' : 'stock-decrease')
+                    },
+                    // Sort by id to display the latest added log in the first row
+                    order: [[0, "desc"]],
+                    columns: [
+                        {
+                            name: "part_name",
+                            data: 1
+                        },
+                        {
+                            name: "description",
+                            data: 2
+                        },
+                        {
+                            name: "status",
+                            data: 3
+                        },
+                        {
+                            name: "done_by",
+                            data: 4
+                        },
+                        {
+                            name: "created_at",
+                            data: 5,
+                            render: dateFormatter
+                        },
+                    ]
+                });
             });
         });
     </script>

--- a/app/urls.py
+++ b/app/urls.py
@@ -12,13 +12,13 @@ from .viewsets import (
 )
 from .views.login import Login
 from .views.signup import SignUp
-from .views.parts import Parts, PartListView
+from .views.parts import Parts, PartListView, PartStockMobilityView
 from .views.aircrafts import Aircrafts, AircraftListView, AircraftProductionListView
 from common.utils import logout
 from common.swagger import schema_view
 from rest_framework.routers import DefaultRouter
 
-# Routers
+# API Routers
 router = DefaultRouter()
 router.register(r"team", TeamViewSet)
 router.register(r"user", UserViewSet)
@@ -44,6 +44,11 @@ urlpatterns = [
         "aircraftProductionsData/",
         AircraftProductionListView.as_view(),
         name="aircraftProductionsData",
+    ),
+    path(
+        "partStockMobilityData/",
+        PartStockMobilityView.as_view(),
+        name="partStockMobilityData",
     ),
     # Swagger Router
     path(

--- a/common/swagger.py
+++ b/common/swagger.py
@@ -12,5 +12,5 @@ schema_view = get_schema_view(
         license=openapi.License(name="BSD License"),
     ),
     public=True,
-    permission_classes=(permissions.AllowAny,),
+    permission_classes=(permissions.AllowAny),
 )


### PR DESCRIPTION
- When the user adds or removes a part, log it as we did when assembling an aircraft
- List part stock mobility on the UI
- Display stock increase mobilities with a green background
- Display stock decrease mobilities with a red background
- Implement default sorting and test sorting, searching functionalities of data table
- Don't display add/remove parts components to the user who is in the assembly team. Assembly team users should only list the data and assembly aircraft